### PR TITLE
Export Data type for consumption

### DIFF
--- a/src/Sloth.elm
+++ b/src/Sloth.elm
@@ -2,6 +2,7 @@ module Sloth
   ( start
   , describe, it, end
   , (=>)
+  , Data
   ) where
 
 
@@ -18,6 +19,9 @@ module Sloth
 import Sloth.Suite as Suite
 import Sloth.Data exposing (..)
 import Sloth.Reporters
+
+
+type alias Data = Sloth.Data.Data
 
 
 {-| Create a `Data` which conatins all test cases and suites. -}


### PR DESCRIPTION
Basically, my linter is mad at me using this tool, because I can't write type annotations for `Data`. 

``` elm
tests =
    start
        `describe` "test"
        `it` "should pass"
        => (1 `shouldBe` 1)
```

^^ Linter mad, no annotation. With this PR I can write the following:

``` elm
tests : Data
tests =
    start
        `describe` "test"
        `it` "should pass"
        => (1 `shouldBe` 1)
```

^^ Many happinesses! 
